### PR TITLE
test: add discovery scenario test

### DIFF
--- a/moltest/discovery.py
+++ b/moltest/discovery.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from pathlib import Path
-import yaml
 
 # Common virtual environment directory names to exclude
 VENV_NAMES = {'.venv', 'venv', 'env'}
@@ -50,12 +49,7 @@ def parse_scenario(molecule_yml_path: Path):
 
     # Placeholder for actual molecule.yml parsing if needed for more details in future
     # try:
-    #     with open(molecule_yml_path, 'r') as f:
-    #         config = yaml.safe_load(f)
-    #     # Extract more details from config if necessary
-    # except Exception as e:
-    #     print(f"Error parsing {molecule_yml_path}: {e}")
-    #     config = {}
+    # Placeholder for reading molecule.yml if needed in the future
 
     return {
         'scenario_name': scenario_name,

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -76,6 +76,10 @@ def mock_dependencies(mocker):
     mocker.patch('moltest.cli.print_scenario_start')
     mocker.patch('moltest.cli.print_scenario_result')
     mocker.patch('moltest.cli.print_summary_table')
+    # Avoid Click's Exit exception being caught by the CLI
+    mocker.patch('click.core.Context.exit', side_effect=lambda self, code=0: (_ for _ in ()).throw(SystemExit(code)))
+    # Skip dependency checks
+    mocker.patch('moltest.cli.check_dependencies')
     # Patch click.echo to capture its output for assertions
     mocked_echo = mocker.patch('moltest.cli.click.echo')
     return mocked_echo

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from moltest.discovery import discover_scenarios
+
+
+def test_discover_scenarios_excludes_venv(tmp_path):
+    """discover_scenarios finds scenarios and skips '.venv' directories."""
+    # Create first scenario
+    role1_scenario = tmp_path / "roles" / "role1" / "molecule" / "alpha"
+    role1_scenario.mkdir(parents=True)
+    (role1_scenario / "molecule.yml").write_text("{}")
+
+    # Create second scenario
+    role2_scenario = tmp_path / "roles" / "role2" / "molecule" / "beta"
+    role2_scenario.mkdir(parents=True)
+    (role2_scenario / "molecule.yml").write_text("{}")
+
+    # Scenario inside .venv should be ignored
+    venv_scenario = tmp_path / ".venv" / "roles" / "venvrole" / "molecule" / "ignored"
+    venv_scenario.mkdir(parents=True)
+    (venv_scenario / "molecule.yml").write_text("{}")
+
+    scenarios = discover_scenarios(tmp_path)
+
+    assert len(scenarios) == 2
+    ids = [s["id"] for s in scenarios]
+    assert ids == ["role1:alpha", "role2:beta"]
+
+    assert scenarios[0]["execution_path"] == str((tmp_path / "roles" / "role1").resolve())
+    assert scenarios[1]["execution_path"] == str((tmp_path / "roles" / "role2").resolve())
+    assert all(Path(s["molecule_file_path"]).exists() for s in scenarios)


### PR DESCRIPTION
## Summary
- add unit test for scenario discovery
- ensure CLI tests patch click exit to avoid Exit capturing
- remove unused yaml import from discovery module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6845a38340f483279e13f6471b0b4a2f