### PR TITLE
fix: stream molecule stderr with output

### DIFF
--- a/moltest/cli.py
+++ b/moltest/cli.py
@@ -223,9 +223,16 @@ def run(ctx, rerun_failed, json_report, md_report, no_color, verbose, scenario):
 
                     # Use Popen to start the process without waiting
                     # stdout=subprocess.PIPE tells Popen to capture the output for us to read
+                    # stderr=subprocess.STDOUT merges stderr into stdout so messages appear in order
                     # text=True decodes the output as text
                     # bufsize=1 enables line-buffering, so we get lines as they are ready
-                    with subprocess.Popen(command_parts, stdout=subprocess.PIPE, text=True, bufsize=1) as proc:
+                    with subprocess.Popen(
+                        command_parts,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                        text=True,
+                        bufsize=1,
+                    ) as proc:
                         # Loop through the output line by line, in real-time
                         for line in proc.stdout:
                             # For now, just print every line to the screen

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -138,6 +138,7 @@ def test_run_streams_output(runner, mock_dependencies, mock_popen):
     expected_echo_calls = [
         mock.call("    | First output line from command"),
         mock.call("    | Second output line"),
+        mock.call("    | Error message from command"),
     ]
 
     # Check if all expected calls are present among the actual calls to click.echo
@@ -150,7 +151,7 @@ def test_run_streams_output(runner, mock_dependencies, mock_popen):
     # Verify Popen was called correctly
     assert mock_popen.cwd_received is None
     assert mock_popen.stdout_pipe_received == subprocess.PIPE
-    assert mock_popen.stderr_pipe_received is None
+    assert mock_popen.stderr_pipe_received == subprocess.STDOUT
     assert mock_popen.text_mode_received is True
     assert mock_popen.bufsize_arg_received == 1
 
@@ -182,6 +183,7 @@ def test_run_streams_without_verbose(runner, mock_dependencies, mock_popen):
 
     # cwd should not be set
     assert mock_popen.cwd_received is None
+    assert mock_popen.stderr_pipe_received == subprocess.STDOUT
 
 
 # TODO: Add more tests:


### PR DESCRIPTION
## Summary
- merge stderr into stdout when running molecule tests
- expect merged stderr output in CLI tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6845b0751d488327ac2eaf3ec37fab37