### PR TITLE
fix: use cwd argument for Molecule command

### DIFF
--- a/moltest/cli.py
+++ b/moltest/cli.py
@@ -200,8 +200,6 @@ def run(ctx, rerun_failed, json_report, md_report, no_color, verbose, scenario):
             ctx.exit(0) # Exit code 0 as no tests were meant to run.
 
         click.echo("\nPreparing to execute Molecule tests for targeted scenarios:")
-        original_cwd = Path.cwd()
-        # original_cwd is defined above the loop
         try:
             for s_data in scenarios_to_run:
                 scenario_id = s_data['id']
@@ -210,12 +208,10 @@ def run(ctx, rerun_failed, json_report, md_report, no_color, verbose, scenario):
                 
                 molecule_command = f"molecule test -s {scenario_name}"
                 print_scenario_start(scenario_id, verbose=verbose)
-                # original_cwd = os.getcwd() # Removed
                 scenario_status = "unknown"
                 duration = None # Initialize duration
                 return_code = -1 # Default/error return code
                 try:
-                    # os.chdir(execution_path) # Removed
                     if verbose > 0:
                         click.echo(f"    Running command: {molecule_command}")
                     command_parts = molecule_command.split()
@@ -232,6 +228,7 @@ def run(ctx, rerun_failed, json_report, md_report, no_color, verbose, scenario):
                         stderr=subprocess.STDOUT,
                         text=True,
                         bufsize=1,
+                        cwd=execution_path,
                     ) as proc:
                         if verbose > 0:
                             # If verbose, stream the output
@@ -273,9 +270,6 @@ def run(ctx, rerun_failed, json_report, md_report, no_color, verbose, scenario):
                     })
                     
                     update_scenario_status(cache_data, scenario_id, scenario_status)
-                    os.chdir(original_cwd)
-                    if verbose > 0: # Make CWD restore message verbose
-                        click.echo(f"    Restored CWD to: {original_cwd}")
         finally:
             click.echo("\nSaving test results to cache...")
             try:

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -149,7 +149,7 @@ def test_run_streams_output_verbose(runner, mock_dependencies, mock_popen):
         assert expected_call in actual_calls, f"Expected echo call '{expected_call}' not found in actual calls: {actual_calls}"
 
     # Verify Popen was called correctly
-    assert mock_popen.cwd_received is None
+    assert mock_popen.cwd_received == Path('/fake/path/role_alpha')
     assert mock_popen.stdout_pipe_received == subprocess.PIPE
     assert mock_popen.stderr_pipe_received == subprocess.STDOUT
     assert mock_popen.text_mode_received is True
@@ -182,8 +182,8 @@ def test_run_consumes_output_without_verbose(runner, mock_dependencies, mock_pop
     # wait() should be called to consume output
     assert mock_popen.wait_called is True
 
-    # cwd should not be set
-    assert mock_popen.cwd_received is None
+    # cwd should be set to the scenario's execution path
+    assert mock_popen.cwd_received == Path('/fake/path/role_alpha')
     assert mock_popen.stderr_pipe_received == subprocess.STDOUT
 
 


### PR DESCRIPTION
## Summary
- avoid changing global working directory when running scenarios
- pass scenario execution path via `cwd` to `subprocess.Popen`
- update tests to expect cwd argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6845b24b36608327ba61989cec3711dd