### PR TITLE
feat: add color toggle and roles path config

### DIFF
--- a/moltest/config.py
+++ b/moltest/config.py
@@ -1,0 +1,30 @@
+import json
+import json
+import os
+from pathlib import Path
+
+CONFIG_DIR = 'moltest'
+CONFIG_FILE = 'config.json'
+
+def _get_config_path() -> Path:
+    base = Path(os.environ.get('XDG_CONFIG_HOME', Path.home() / '.config'))
+    cfg_dir = base / CONFIG_DIR
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    return cfg_dir / CONFIG_FILE
+
+
+def load_config() -> dict:
+    path = _get_config_path()
+    if path.is_file():
+        try:
+            with open(path, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        except Exception:
+            return {}
+    return {}
+
+
+def save_config(cfg: dict) -> None:
+    path = _get_config_path()
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(cfg, f, indent=4)

--- a/moltest/reporter.py
+++ b/moltest/reporter.py
@@ -24,13 +24,21 @@ STYLE_BOLD = Style.BRIGHT
 STYLE_DIM = Style.DIM
 STYLE_NORMAL = Style.NORMAL
 
-def print_scenario_start(scenario_id: str, verbose: int = 0):
-    """Prints a message indicating the start of a scenario."""
-    # Basic implementation for now, verbose not used yet
-    print(f"{COLOR_INFO}RUNNING: {scenario_id} ...")
+def print_scenario_start(scenario_id: str, verbose: int = 0, *, color_enabled: bool = True):
+    """Print a message indicating the start of a scenario."""
+    color = COLOR_INFO if color_enabled else ""
+    reset = Style.RESET_ALL if color_enabled else ""
+    print(f"{color}RUNNING: {scenario_id} ...{reset}")
 
-def print_scenario_result(scenario_id: str, status: str, duration: float = None, verbose: int = 0):
-    """Prints the result of a scenario execution with color coding."""
+def print_scenario_result(
+    scenario_id: str,
+    status: str,
+    duration: float | None = None,
+    verbose: int = 0,
+    *,
+    color_enabled: bool = True,
+) -> None:
+    """Print the result of a scenario execution with optional color."""
     status_upper = status.upper()
     
     if status_upper == "PASSED":
@@ -41,18 +49,28 @@ def print_scenario_result(scenario_id: str, status: str, duration: float = None,
         status_text = "FAILED"
     else:
         color = COLOR_WARNING
-        status_text = status_upper # Or some other default
+        status_text = status_upper
         
     duration_str = f" ({duration:.2f}s)" if duration is not None else ""
-    
-    # Basic implementation for now, verbose not used yet
-    print(f"{color}{STYLE_BOLD}{status_text}:{STYLE_NORMAL} {scenario_id}{duration_str}")
+
+    color_prefix = color + STYLE_BOLD if color_enabled else ""
+    color_reset = Style.RESET_ALL if color_enabled else ""
+    style_normal = STYLE_NORMAL if color_enabled else ""
+    print(f"{color_prefix}{status_text}:{style_normal} {scenario_id}{duration_str}{color_reset}")
 
 
-def print_summary_table(scenario_results: list, overall_duration: float = None, verbose: int = 0):
-    """Prints a summary table of all scenario results."""
+def print_summary_table(
+    scenario_results: list,
+    overall_duration: float | None = None,
+    verbose: int = 0,
+    *,
+    color_enabled: bool = True,
+) -> None:
+    """Print a summary table of all scenario results."""
     if not scenario_results:
-        print(f"{COLOR_WARNING}No scenario results to summarize.")
+        prefix = COLOR_WARNING if color_enabled else ""
+        reset = Style.RESET_ALL if color_enabled else ""
+        print(f"{prefix}No scenario results to summarize.{reset}")
         return
 
     num_total = len(scenario_results)
@@ -67,10 +85,14 @@ def print_summary_table(scenario_results: list, overall_duration: float = None, 
     status_col_len = len("  Status  ") # Length of "  PASSED  " or "  FAILED  "
     duration_col_len = len("(000.00s)") # Max duration string length
 
-    print(f"\n{COLOR_HEADER}{STYLE_BOLD}{'=' * 20} Test Execution Summary {'=' * 20}{STYLE_NORMAL}")
+    header_prefix = COLOR_HEADER + STYLE_BOLD if color_enabled else ""
+    reset = Style.RESET_ALL if color_enabled else ""
+    print(f"\n{header_prefix}{'=' * 20} Test Execution Summary {'=' * 20}{reset}")
     
     # Header row
-    header = f"{STYLE_BOLD}{'Scenario ID':<{max_id_len}}  {'Status':^{status_col_len}}  {'Duration':>{duration_col_len}}{STYLE_NORMAL}"
+    style_bold = STYLE_BOLD if color_enabled else ""
+    style_normal = STYLE_NORMAL if color_enabled else ""
+    header = f"{style_bold}{'Scenario ID':<{max_id_len}}  {'Status':^{status_col_len}}  {'Duration':>{duration_col_len}}{style_normal}"
     print(header)
     print(f"{'-' * (max_id_len + status_col_len + duration_col_len + 4)}") # Separator line
 
@@ -91,21 +113,27 @@ def print_summary_table(scenario_results: list, overall_duration: float = None, 
         
         duration_display = f"({s_duration:.2f}s)" if s_duration is not None else ""
         
-        print(f"{s_id:<{max_id_len}}  {color}{STYLE_BOLD}{status_display:^{status_col_len}}{STYLE_NORMAL}  {duration_display:>{duration_col_len}}")
+        prefix = color + STYLE_BOLD if color_enabled else ""
+        print(
+            f"{s_id:<{max_id_len}}  {prefix}{status_display:^{status_col_len}}{style_normal if color_enabled else ''}  {duration_display:>{duration_col_len}}{reset if color_enabled else ''}"
+        )
 
-    print(f"{'-' * (max_id_len + status_col_len + duration_col_len + 4)}") # Separator line
+    print(f"{'-' * (max_id_len + status_col_len + duration_col_len + 4)}")  # Separator line
 
     # Summary counts
-    summary_line = f"{STYLE_BOLD}Total Scenarios: {num_total}{STYLE_NORMAL} | " \
-                   f"{COLOR_SUCCESS}{STYLE_BOLD}Passed: {num_passed}{STYLE_NORMAL} | " \
-                   f"{COLOR_FAILURE}{STYLE_BOLD}Failed: {num_failed}{STYLE_NORMAL}"
+    summary_line = (
+        f"{style_bold}Total Scenarios: {num_total}{style_normal} | "
+        f"{(COLOR_SUCCESS + STYLE_BOLD) if color_enabled else ''}Passed: {num_passed}{style_normal} | "
+        f"{(COLOR_FAILURE + STYLE_BOLD) if color_enabled else ''}Failed: {num_failed}{style_normal}"
+    )
     if num_other > 0:
-        summary_line += f" | {COLOR_WARNING}{STYLE_BOLD}Other: {num_other}{STYLE_NORMAL}"
+        summary_line += f" | {(COLOR_WARNING + STYLE_BOLD) if color_enabled else ''}Other: {num_other}{style_normal}"
     print(summary_line)
 
     if overall_duration is not None:
-        print(f"{STYLE_BOLD}Total Execution Time: {overall_duration:.2f}s{STYLE_NORMAL}")
-    print(f"{COLOR_HEADER}{STYLE_BOLD}{'=' * (len(header) + 0)}{STYLE_NORMAL}") # Match header length
+        print(f"{style_bold}Total Execution Time: {overall_duration:.2f}s{style_normal}")
+    footer_prefix = COLOR_HEADER + STYLE_BOLD if color_enabled else ""
+    print(f"{footer_prefix}{'=' * (len(header) + 0)}{reset}")  # Match header length
 
 
 def generate_json_report(scenario_results: list, report_path: str, overall_duration: float = None, verbose: int = 0):

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -77,6 +77,7 @@ def mock_dependencies(mocker):
     mocker.patch('click.core.Context.exit', side_effect=lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
     # Skip dependency checks
     mocker.patch('moltest.cli.check_dependencies')
+    mocker.patch('moltest.cli.click.prompt', return_value='roles')
     # Patch click.echo to capture its output for assertions
     mocked_echo = mocker.patch('moltest.cli.click.echo')
     return mocked_echo
@@ -200,6 +201,7 @@ def mock_dependencies_no_scenarios(mocker):
     mocker.patch('moltest.cli.print_summary_table')
     mocker.patch('click.core.Context.exit', side_effect=lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
     mocker.patch('moltest.cli.check_dependencies')
+    mocker.patch('moltest.cli.click.prompt', return_value='roles')
     mocked_echo = mocker.patch('moltest.cli.click.echo')
     return mocked_echo
 
@@ -217,6 +219,7 @@ def mock_dependencies_multi(mocker):
     mocker.patch('moltest.cli.print_summary_table')
     mocker.patch('click.core.Context.exit', side_effect=lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
     mocker.patch('moltest.cli.check_dependencies')
+    mocker.patch('moltest.cli.click.prompt', return_value='roles')
     mocked_echo = mocker.patch('moltest.cli.click.echo')
     return mocked_echo
 

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -51,3 +51,19 @@ def test_generate_reports_empty(tmp_path):
     md_content = md_path.read_text()
     assert "No scenario results to report." in md_content
 
+
+def test_no_color_output(capsys):
+    from moltest.reporter import print_scenario_result, print_summary_table
+
+    print_scenario_result("role1:alpha", "passed", duration=1.0, color_enabled=False)
+    out1 = capsys.readouterr().out
+    assert "\x1b[" not in out1
+    assert "PASSED" in out1
+
+    print_summary_table([
+        {"id": "role1:alpha", "status": "passed", "duration": 1.0}
+    ], color_enabled=False)
+    out2 = capsys.readouterr().out
+    assert "\x1b[" not in out2
+    assert "role1:alpha" in out2
+


### PR DESCRIPTION
## Summary
- allow reporter functions to disable color output
- store default roles path under XDG config directory
- read and prompt for roles path when not provided
- pass color flag through CLI to reporter
- test no-color behaviour and update CLI tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6845b750d0688327833bc874efb344c3