### PR TITLE
feat: add --lf alias and CI color detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ moltest run [OPTIONS]
 **Options for `run`:**
 
 *   `--scenario TEXT`: Specify a particular scenario name to run (e.g., `default`). If not provided, all discovered scenarios are run.
-*   `--rerun-failed`: Only run scenarios that failed in the last execution (based on the cache).
+*   `--rerun-failed`, `--lf`, `-f`: Only run scenarios that failed in the last execution (based on the cache).
 *   `--json-report [PATH]`: Save a JSON report. Defaults to `moltest_report.json` if no path is provided.
 *   `--md-report [PATH]`: Save a Markdown report. Defaults to `moltest_report.md` if no path is provided.
 *   `--roles-path [PATH]`: Directory containing Ansible roles (used for `ANSIBLE_ROLES_PATH`, default: `roles`).
-*   `--no-color`: Disable colored output in the console.
+*   `--no-color`: Disable colored output in the console. This is automatically enabled in CI environments or when stdout is not a TTY.
 *   `--verbose INTEGER`: Set verbosity level (0, 1, 2). Higher numbers provide more output.
 *   `--help`: Show help for the `run` command.
 

--- a/moltest/cli.py
+++ b/moltest/cli.py
@@ -130,7 +130,14 @@ def validate_report_path(ctx, param, value, expected_extension):
 
 @cli.command()
 @click.pass_context # Add pass_context decorator
-@click.option('--rerun-failed', '-f', is_flag=True, help='Rerun only the failed tests.')
+@click.option(
+    '--rerun-failed',
+    '--lf',
+    '-f',
+    'rerun_failed',
+    is_flag=True,
+    help='Rerun only the failed tests.'
+)
 @click.option('--json-report', '-j',
               type=click.Path(dir_okay=False, writable=True, resolve_path=True),
               flag_value=DEFAULT_JSON_REPORT,
@@ -157,8 +164,10 @@ def run(ctx, rerun_failed, json_report, md_report, no_color, verbose, scenario, 
     """Run Molecule tests."""
     check_dependencies(ctx)  # Call dependency check early
 
-    color_env = os.getenv('CI', '').lower() != 'true' and sys.stdout.isatty()
-    color_enabled = not no_color and color_env
+    if os.getenv('CI', '').lower() == 'true' or not sys.stdout.isatty():
+        no_color = True
+
+    color_enabled = not no_color
 
     config = load_config()
     if roles_path is None:

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -237,6 +237,22 @@ def test_run_failing_scenario_exit_code(runner, mock_dependencies_multi, mock_po
     assert result.exit_code == 1
 
 
+def test_lf_alias_invokes_rerun_failed(runner, mock_dependencies, mock_popen):
+    """--lf should behave as an alias for --rerun-failed."""
+    result = runner.invoke(cli, ['run', '--lf'])
+    assert result.exit_code == 0
+    mock_dependencies.assert_any_call('Rerun failed: True')
+
+
+def test_no_color_auto_enabled_in_ci(runner, mock_dependencies, mock_popen, monkeypatch):
+    """CI environment should force no-color output."""
+    monkeypatch.setenv('CI', 'true')
+    monkeypatch.setattr('sys.stdout.isatty', lambda: True)
+    result = runner.invoke(cli, ['run'])
+    assert result.exit_code == 0
+    mock_dependencies.assert_any_call('No color: True')
+
+
 import click
 
 from moltest.cli import validate_report_path


### PR DESCRIPTION
## Summary
- add `--lf` alias for `--rerun-failed`
- disable color automatically in CI or when stdout isn't a TTY
- document new option and color autodetection
- test `--lf` alias and CI color detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6845b938dfd883279922257ee46158cb