### PR TITLE
fix: gate debug output behind verbosity

### DIFF
--- a/moltest/cli.py
+++ b/moltest/cli.py
@@ -182,22 +182,24 @@ def run(ctx, rerun_failed, json_report, md_report, no_color, verbose, scenario, 
         if roles_path != config.get('roles_path'):
             save_config({'roles_path': roles_path})
 
-    click.echo(f"Rerun failed: {rerun_failed}")
-    click.echo(f"JSON report: {json_report}")
-    click.echo(f"Markdown report: {md_report}")
-    click.echo(f"No color: {no_color}")
-    click.echo(f"  Verbose: {verbose}")
-    click.echo(f"  Scenario(s) selected: {scenario}")
-    click.echo(f"  Roles path: {roles_path}")
+    if verbose > 0:
+        click.echo(f"Rerun failed: {rerun_failed}")
+        click.echo(f"JSON report: {json_report}")
+        click.echo(f"Markdown report: {md_report}")
+        click.echo(f"No color: {no_color}")
+        click.echo(f"  Verbose: {verbose}")
+        click.echo(f"  Scenario(s) selected: {scenario}")
+        click.echo(f"  Roles path: {roles_path}")
 
     roles_path_resolved = Path(roles_path)
     if not roles_path_resolved.is_absolute():
         roles_path_resolved = (_PROJECT_ROOT / roles_path_resolved).resolve()
-    click.echo(f"  Using roles path: {roles_path_resolved}")
+    if verbose > 0:
+        click.echo(f"  Using roles path: {roles_path_resolved}")
 
-    # _PROJECT_ROOT is defined at the top of the file by the cache import setup
-    click.echo(f"\nProject root: {_PROJECT_ROOT}")
-    click.echo(f"Discovering scenarios from: {_PROJECT_ROOT}")
+        # _PROJECT_ROOT is defined at the top of the file by the cache import setup
+        click.echo(f"\nProject root: {_PROJECT_ROOT}")
+        click.echo(f"Discovering scenarios from: {_PROJECT_ROOT}")
 
     try:
         cache_data = load_cache(str(_PROJECT_ROOT))

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -242,14 +242,14 @@ def test_run_failing_scenario_exit_code(runner, mock_dependencies_multi, mock_po
 
 def test_lf_alias_invokes_rerun_failed(runner, mock_dependencies, mock_popen):
     """--lf should behave as an alias for --rerun-failed."""
-    result = runner.invoke(cli, ['run', '--lf'])
+    result = runner.invoke(cli, ['run', '--lf', '-v'])
     assert result.exit_code == 0
     mock_dependencies.assert_any_call('Rerun failed: True')
 
 
 def test_f_alias_invokes_rerun_failed(runner, mock_dependencies, mock_popen):
     """-f short option should also trigger rerun-failed."""
-    result = runner.invoke(cli, ['run', '-f'])
+    result = runner.invoke(cli, ['run', '-f', '-v'])
     assert result.exit_code == 0
     mock_dependencies.assert_any_call('Rerun failed: True')
 
@@ -258,14 +258,14 @@ def test_no_color_auto_enabled_in_ci(runner, mock_dependencies, mock_popen, monk
     """CI environment should force no-color output."""
     monkeypatch.setenv('CI', 'true')
     monkeypatch.setattr('sys.stdout.isatty', lambda: True)
-    result = runner.invoke(cli, ['run'])
+    result = runner.invoke(cli, ['run', '-v'])
     assert result.exit_code == 0
     mock_dependencies.assert_any_call('No color: True')
 
 
 def test_no_color_flag(runner, mock_dependencies, mock_popen):
     """Explicit --no-color option disables colored output."""
-    result = runner.invoke(cli, ['run', '--no-color'])
+    result = runner.invoke(cli, ['run', '--no-color', '-v'])
     assert result.exit_code == 0
     mock_dependencies.assert_any_call('No color: True')
 


### PR DESCRIPTION
## Summary
- only show debug setup info when verbose flag is used
- update tests to call `moltest run` with `-v` when checking debug output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6845bf2dd70c8327814b476b3bdce43e