### PR TITLE
feat: add scenario expression filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ moltest run [OPTIONS]
 **Options for `run`:**
 
 *   `--scenario TEXT`: Specify a particular scenario name to run (e.g., `default`). If not provided, all discovered scenarios are run.
+*   `-k EXPRESSION`: Filter scenarios by ID using a boolean expression (similar to pytest). Words are matched as substrings.
 *   `--rerun-failed`, `--lf`, `-f`: Only run scenarios that failed in the last execution (based on the cache).
 *   `--json-report [PATH]`, `-j`: Save a JSON report. Defaults to `moltest_report.json` if no path is provided.
 *   `--md-report [PATH]`, `-m`: Save a Markdown report. Defaults to `moltest_report.md` if no path is provided.
@@ -113,6 +114,10 @@ moltest run [OPTIONS]
 *   Rerun only scenarios that failed previously:
     ```bash
     moltest run --rerun-failed
+    ```
+*   Filter scenarios with an expression:
+    ```bash
+    moltest run -k "web and not slow"
     ```
 *   Run all scenarios and save reports to custom paths:
     ```bash

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -416,3 +416,22 @@ def test_run_parameter_sets(runner, mock_dependencies_params, mock_popen):
     assert 'role1:alpha[set1]' in starts
     assert 'role1:alpha[set2]' in starts
 
+
+def test_k_expression_filters_scenarios(runner, mock_dependencies_multi, mock_popen):
+    """-k expression should filter scenarios by ID."""
+    result = runner.invoke(cli, ['run', '-k', 'role1'])
+    assert result.exit_code == 0
+
+    # Only the matching scenario should run
+    cwds = [entry['cwd'] for entry in mock_popen.call_history]
+    assert cwds == [Path('/fake/path/role1')]
+
+
+def test_k_expression_no_match(runner, mock_dependencies_multi, mock_popen):
+    """No scenarios should run if -k expression matches none."""
+    result = runner.invoke(cli, ['run', '-k', 'nonexistent'])
+    assert result.exit_code == 0
+    assert mock_popen.call_history == []
+    echo_msgs = [c.args[0] for c in mock_dependencies_multi.call_args_list]
+    assert any('No Molecule tests will be run' in m for m in echo_msgs)
+


### PR DESCRIPTION
## Summary
- add `-k` option to filter scenarios by expression
- implement `compile_id_expression` helper
- document filtering in README
- test matching and non-matching expressions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6845c6d31cd88327b38ff4e5ca3dde57