### PR TITLE
feat: add plugin hooks and loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ For more detailed testing instructions, including how to run specific tests, see
 
 See [docs/reporter_examples.md](docs/reporter_examples.md) for short snippets showing how to use the functions in `moltest.reporter` for colorized output and report generation.
 
+## Plugin Hooks
+
+MolTest can load user-defined Python modules that implement optional hook functions.
+See [docs/plugin_example.md](docs/plugin_example.md) for a minimal example of how
+to register a plugin and the available hook names.
+
 ## Contributing
 
 (Details on how to contribute, coding standards, pull request process, etc., to be added.)

--- a/docs/plugin_example.md
+++ b/docs/plugin_example.md
@@ -1,0 +1,35 @@
+# Plugin Example
+
+MolTest can be extended by loading Python modules that define optional hook functions.
+The CLI looks for entry points under the group `moltest.plugins` and for module
+names listed in the user's configuration file under the `plugins` key.
+
+Plugins can implement any of the following hooks:
+
+- `before_run(ctx)` – called right after plugins are loaded.
+- `after_run(results)` – called before the process exits with the list of scenario results.
+- `before_scenario(scenario_id)` – called before each scenario is executed.
+- `after_scenario(scenario_id, status)` – called after each scenario completes.
+
+```python
+# my_plugin.py
+from typing import List
+
+events: List[str] = []
+
+def before_run(ctx):
+    events.append("before_run")
+
+def before_scenario(scenario_id):
+    events.append(f"before:{scenario_id}")
+
+def after_scenario(scenario_id, status):
+    events.append(f"after:{scenario_id}:{status}")
+
+def after_run(results):
+    events.append("after_run")
+```
+
+Add `"my_plugin"` to the `plugins` list in your `~/.config/moltest/config.json`
+(or expose it via a `moltest.plugins` entry point) and the hook functions will be
+invoked during `moltest run`.

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,66 @@
+import importlib
+from click.testing import CliRunner
+
+from moltest.cli import cli
+
+
+def test_hooks_execute(tmp_path, mocker, monkeypatch):
+    plugin_path = tmp_path / "sample_plugin.py"
+    plugin_path.write_text(
+        """
+Events = []
+
+def before_run(ctx):
+    Events.append('before_run')
+
+def before_scenario(sid):
+    Events.append(f'before:{sid}')
+
+def after_scenario(sid, status):
+    Events.append(f'after:{sid}:{status}')
+
+def after_run(results):
+    Events.append('after_run')
+"""
+    )
+    monkeypatch.syspath_prepend(tmp_path)
+
+    mocker.patch('moltest.cli.discover_scenarios', return_value=[
+        {'id': 'role:test', 'scenario_name': 'default', 'execution_path': '/fake/path'}
+    ])
+    mocker.patch('moltest.cli.load_cache', return_value={'moltest_version': '0.1.0', 'last_run': '', 'scenarios': {}})
+    mocker.patch('moltest.cli.save_cache')
+    mocker.patch('moltest.cli.print_scenario_start')
+    mocker.patch('moltest.cli.print_scenario_result')
+    mocker.patch('moltest.cli.print_summary_table')
+    mocker.patch('click.core.Context.exit', side_effect=lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+    mocker.patch('moltest.cli.check_dependencies')
+    mocker.patch('moltest.cli.click.prompt', return_value='roles')
+    mocker.patch('moltest.cli.generate_json_report')
+    mocker.patch('moltest.cli.generate_markdown_report')
+
+    monkeypatch.setattr('moltest.cli.load_config', lambda: {'plugins': ['sample_plugin'], 'roles_path': 'roles'})
+    monkeypatch.setattr('importlib.metadata.entry_points', lambda group=None: [])
+
+    class DummyProc:
+        def __init__(self, *a, **k):
+            self.returncode = 0
+            self.stdout = []
+        def __enter__(self):
+            return self
+        def __exit__(self, exc, val, tb):
+            pass
+        def wait(self):
+            return 0
+
+    mocker.patch('moltest.cli.subprocess.Popen', return_value=DummyProc())
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ['run'])
+    assert result.exit_code == 0
+
+    plugin = importlib.import_module('sample_plugin')
+    assert plugin.Events[0] == 'before_run'
+    assert 'before:role:test' in plugin.Events
+    assert 'after:role:test:passed' in plugin.Events or 'after:role:test:failed' in plugin.Events
+    assert plugin.Events[-1] == 'after_run'


### PR DESCRIPTION
## Summary
- add hook system to `moltest.cli`
- allow plugins via entry points or config
- document plugin usage
- test plugin hook execution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6845c7d4b6e48327b4f677bc4952d82e