### PR TITLE
feat: add JUnit XML reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The primary goal of MolTest is to improve the efficiency and user experience of 
 
 *   **Batch Execution:** Run all discovered Molecule scenarios with a single command.
 *   **Targeted Testing:** Easily rerun only previously failed tests, saving significant time during development and CI.
-*   **Clear Reporting:** Generate human-readable (Markdown) and machine-readable (JSON) reports of test outcomes.
+*   **Clear Reporting:** Generate human-readable (Markdown) and machine-readable (JSON or JUnit XML) reports of test outcomes.
 *   **Simplified Workflow:** Provide a consistent interface for interacting with Molecule tests across different projects.
 *   **CI/CD Integration:** Offer features and output formats suitable for integration into automated testing pipelines.
 
@@ -18,7 +18,7 @@ The primary goal of MolTest is to improve the efficiency and user experience of 
 *   **Test Execution:** Runs selected or all discovered Molecule scenarios.
 *   **Results Caching:** Persists test results (pass/fail status, duration, return codes) in a local `.moltest_cache.json` file.
 *   **Rerun Failed:** Supports rerunning only the scenarios that failed in the previous execution.
-*   **Report Generation:** Creates detailed test reports in JSON and Markdown formats.
+*   **Report Generation:** Creates detailed test reports in JSON, Markdown, and JUnit XML formats.
 *   **Flexible CLI:** Offers commands to `run` tests, `clear-cache`, and `show-cache`.
 *   **Dependency Checks:** Verifies the presence and minimum versions of `molecule` and `ansible`.
 
@@ -96,6 +96,7 @@ moltest run [OPTIONS]
 *   `--rerun-failed`, `--lf`, `-f`: Only run scenarios that failed in the last execution (based on the cache).
 *   `--json-report [PATH]`, `-j`: Save a JSON report. Defaults to `moltest_report.json` if no path is provided.
 *   `--md-report [PATH]`, `-m`: Save a Markdown report. Defaults to `moltest_report.md` if no path is provided.
+*   `--junit-xml [PATH]`, `-x`: Save results in JUnit XML format. Defaults to `moltest_report.xml` if no path is provided.
 *   `--roles-path [PATH]`: Directory containing Ansible roles (used for `ANSIBLE_ROLES_PATH`, default: `roles`).
 *   `--no-color`: Disable colored output in the console. This is automatically enabled in CI environments or when stdout is not a TTY.
 *   `--verbose INTEGER`: Set verbosity level (0, 1, 2). Higher numbers provide more output.
@@ -121,7 +122,7 @@ moltest run [OPTIONS]
     ```
 *   Run all scenarios and save reports to custom paths:
     ```bash
-    moltest run --json-report custom_results.json --md-report custom_summary.md
+    moltest run --json-report custom_results.json --md-report custom_summary.md --junit-xml custom_results.xml
     ```
 
 ### Managing the Cache

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -83,6 +83,7 @@ def mock_dependencies(mocker):
     # Prevent actual report generation during tests
     mocker.patch('moltest.cli.generate_json_report')
     mocker.patch('moltest.cli.generate_markdown_report')
+    mocker.patch('moltest.cli.generate_junit_xml_report')
     # Patch click.echo to capture its output for assertions
     mocked_echo = mocker.patch('moltest.cli.click.echo')
     return mocked_echo
@@ -213,6 +214,7 @@ def mock_dependencies_no_scenarios(mocker):
     mocker.patch('click.core.Context.exit', side_effect=lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
     mocker.patch('moltest.cli.check_dependencies')
     mocker.patch('moltest.cli.click.prompt', return_value='roles')
+    mocker.patch('moltest.cli.generate_junit_xml_report')
     mocked_echo = mocker.patch('moltest.cli.click.echo')
     return mocked_echo
 
@@ -231,6 +233,7 @@ def mock_dependencies_multi(mocker):
     mocker.patch('click.core.Context.exit', side_effect=lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
     mocker.patch('moltest.cli.check_dependencies')
     mocker.patch('moltest.cli.click.prompt', return_value='roles')
+    mocker.patch('moltest.cli.generate_junit_xml_report')
     mocked_echo = mocker.patch('moltest.cli.click.echo')
     return mocked_echo
 
@@ -249,6 +252,7 @@ def mock_dependencies_tagged(mocker):
     mocker.patch('click.core.Context.exit', side_effect=lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
     mocker.patch('moltest.cli.check_dependencies')
     mocker.patch('moltest.cli.click.prompt', return_value='roles')
+    mocker.patch('moltest.cli.generate_junit_xml_report')
     mocked_echo = mocker.patch('moltest.cli.click.echo')
     return mocked_echo
 
@@ -275,6 +279,7 @@ def mock_dependencies_params(mocker):
     mocker.patch('click.core.Context.exit', side_effect=lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
     mocker.patch('moltest.cli.check_dependencies')
     mocker.patch('moltest.cli.click.prompt', return_value='roles')
+    mocker.patch('moltest.cli.generate_junit_xml_report')
     echo = mocker.patch('moltest.cli.click.echo')
     return {'echo': echo, 'start': start, 'result': result}
 
@@ -352,15 +357,18 @@ def test_default_report_paths(tmp_path, runner, mocker, monkeypatch, mock_popen,
         monkeypatch.setattr('moltest.cli._PROJECT_ROOT', Path.cwd())
         mock_json = mocker.patch('moltest.cli.generate_json_report')
         mock_md = mocker.patch('moltest.cli.generate_markdown_report')
+        mock_xml = mocker.patch('moltest.cli.generate_junit_xml_report')
 
-        result = runner.invoke(cli, ['run', '-j', '-m'])
+        result = runner.invoke(cli, ['run', '-j', '-m', '-x'])
         assert result.exit_code == 0
 
         expected_json = str(Path('moltest_report.json').resolve())
         expected_md = str(Path('moltest_report.md').resolve())
+        expected_xml = str(Path('moltest_report.xml').resolve())
 
         assert mock_json.call_args[0][1] == expected_json
         assert mock_md.call_args[0][1] == expected_md
+        assert mock_xml.call_args[0][1] == expected_xml
 
 
 def test_run_uses_correct_cwd_multiple_scenarios(runner, mock_dependencies_multi, mock_popen):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -38,6 +38,7 @@ def after_run(results):
     mocker.patch('moltest.cli.click.prompt', return_value='roles')
     mocker.patch('moltest.cli.generate_json_report')
     mocker.patch('moltest.cli.generate_markdown_report')
+    mocker.patch('moltest.cli.generate_junit_xml_report')
 
     monkeypatch.setattr('moltest.cli.load_config', lambda: {'plugins': ['sample_plugin'], 'roles_path': 'roles'})
     monkeypatch.setattr('importlib.metadata.entry_points', lambda group=None: [])

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -1,5 +1,10 @@
 import json
-from moltest.reporter import generate_json_report, generate_markdown_report
+import xml.etree.ElementTree as ET
+from moltest.reporter import (
+    generate_json_report,
+    generate_markdown_report,
+    generate_junit_xml_report,
+)
 
 
 def test_generate_reports(tmp_path):
@@ -11,9 +16,11 @@ def test_generate_reports(tmp_path):
 
     json_path = tmp_path / "report.json"
     md_path = tmp_path / "report.md"
+    xml_path = tmp_path / "report.xml"
 
     generate_json_report(scenario_results, str(json_path), overall_duration=3.0)
     generate_markdown_report(scenario_results, str(md_path), overall_duration=3.0)
+    generate_junit_xml_report(scenario_results, str(xml_path), overall_duration=3.0)
 
     data = json.loads(json_path.read_text())
     assert data["total_scenarios"] == 3
@@ -33,13 +40,28 @@ def test_generate_reports(tmp_path):
     assert "- **Total Scenarios:** 3" in md_lines
     assert "| role2:beta | ❌ Failed | 2.00 |" in md_lines
 
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+    assert root.tag == "testsuite"
+    assert root.attrib["tests"] == "3"
+    assert root.attrib["failures"] == "1"
+    assert root.attrib["skipped"] == "1"
+    cases = root.findall("testcase")
+    assert len(cases) == 3
+    fail_case = [c for c in cases if c.attrib["name"] == "beta"][0]
+    assert fail_case.find("failure") is not None
+    skip_case = [c for c in cases if c.attrib["name"] == "gamma"][0]
+    assert skip_case.find("skipped") is not None
+
 
 def test_generate_reports_empty(tmp_path):
     json_path = tmp_path / "empty.json"
     md_path = tmp_path / "empty.md"
+    xml_path = tmp_path / "empty.xml"
 
     generate_json_report([], str(json_path))
     generate_markdown_report([], str(md_path))
+    generate_junit_xml_report([], str(xml_path))
 
     data = json.loads(json_path.read_text())
     assert data["total_scenarios"] == 0
@@ -50,6 +72,11 @@ def test_generate_reports_empty(tmp_path):
 
     md_content = md_path.read_text()
     assert "No scenario results to report." in md_content
+
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+    assert root.attrib["tests"] == "0"
+    assert root.attrib["failures"] == "0"
 
 
 def test_no_color_output(capsys):


### PR DESCRIPTION
## Summary
- implement `generate_junit_xml_report`
- support `--junit-xml` CLI option with default path
- update README docs for new flag
- test XML output and CLI handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6845ca943ec0832789faeef08ca68010