### PR TITLE
feat: add fail-fast and maxfail options

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ moltest run [OPTIONS]
 *   `--roles-path [PATH]`: Directory containing Ansible roles (used for `ANSIBLE_ROLES_PATH`, default: `roles`).
 *   `--no-color`: Disable colored output in the console. This is automatically enabled in CI environments or when stdout is not a TTY.
 *   `--verbose INTEGER`: Set verbosity level (0, 1, 2). Higher numbers provide more output.
+*   `--fail-fast`: Stop execution after the first failure.
+*   `--maxfail INTEGER`: Abort after N failures (0 for unlimited).
 *   `--help`: Show help for the `run` command.
 
 **Examples:**


### PR DESCRIPTION
## Summary
- add `--fail-fast` and `--maxfail` options to the `run` command
- stop scenario execution early when failure thresholds are reached
- document new options in README
- test early termination behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6845cd39ffb08327b6c399865107c6e1