### PR TITLE
feat: add collect-only and fixtures options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The primary goal of MolTest is to improve the efficiency and user experience of 
 *   **Rerun Failed:** Supports rerunning only the scenarios that failed in the previous execution.
 *   **Report Generation:** Creates detailed test reports in JSON, Markdown, and JUnit XML formats.
 *   **Flexible CLI:** Offers commands to `run` tests, `clear-cache`, and `show-cache`.
+*   **Collection and Fixture Listing:** Use `--collect-only` to list scenarios without running them and `--fixtures` to show available parameter sets.
 *   **Dependency Checks:** Verifies the presence and minimum versions of `molecule` and `ansible`.
 
 ## Requirements
@@ -102,6 +103,8 @@ moltest run [OPTIONS]
 *   `--verbose INTEGER`: Set verbosity level (0, 1, 2). Higher numbers provide more output.
 *   `--fail-fast`: Stop execution after the first failure.
 *   `--maxfail INTEGER`: Abort after N failures (0 for unlimited).
+*   `--collect-only`: List scenario IDs (including parameter identifiers) without running Molecule.
+*   `--fixtures`: Show parameter set names for each discovered scenario and exit.
 *   `--help`: Show help for the `run` command.
 
 **Examples:**
@@ -121,6 +124,14 @@ moltest run [OPTIONS]
 *   Filter scenarios with an expression:
     ```bash
     moltest run -k "web and not slow"
+    ```
+*   List scenarios without running them:
+    ```bash
+    moltest run --collect-only
+    ```
+*   Show parameter sets for each scenario:
+    ```bash
+    moltest run --fixtures
     ```
 *   Run all scenarios and save reports to custom paths:
     ```bash

--- a/moltest/cli.py
+++ b/moltest/cli.py
@@ -326,6 +326,16 @@ def _run_scenario(record, verbose, roles_path_resolved):
     help='Abort after this many failures. 0 means unlimited.'
 )
 @click.option(
+    '--collect-only',
+    is_flag=True,
+    help='List discovered scenarios without running them.'
+)
+@click.option(
+    '--fixtures',
+    is_flag=True,
+    help='Display parameter sets for each scenario and exit.'
+)
+@click.option(
     '--roles-path',
     '-r',
     type=click.Path(file_okay=False, resolve_path=True),
@@ -333,7 +343,8 @@ def _run_scenario(record, verbose, roles_path_resolved):
     help='Directory containing Ansible roles. Used for ANSIBLE_ROLES_PATH.',
 )
 def run(ctx, rerun_failed, json_report, md_report, junit_xml, no_color, verbose, scenario,
-        id_expr, skip_tags, xfail_tags, parallel, fail_fast, maxfail, roles_path):  # Add ctx parameter
+        id_expr, skip_tags, xfail_tags, parallel, fail_fast, maxfail,
+        collect_only, fixtures, roles_path):  # Add ctx parameter
     """Run Molecule tests."""
     check_dependencies(ctx)  # Call dependency check early
 
@@ -397,6 +408,18 @@ def run(ctx, rerun_failed, json_report, md_report, junit_xml, no_color, verbose,
     
     try:
         all_discovered_scenarios = discover_scenarios(_PROJECT_ROOT)
+        if fixtures:
+            click.echo("Scenario fixtures:")
+            for s_data_item in all_discovered_scenarios:
+                click.echo(f"{s_data_item['id']}:")
+                params = s_data_item.get('parameters') or []
+                if params:
+                    for idx, param in enumerate(params):
+                        pid = param.get('id', str(idx))
+                        click.echo(f"  - {pid}")
+                else:
+                    click.echo("  <none>")
+            ctx.exit(0)
         if all_discovered_scenarios:
             click.echo("Discovered scenario IDs:")
             for s_data_item in all_discovered_scenarios:
@@ -456,6 +479,25 @@ def run(ctx, rerun_failed, json_report, md_report, junit_xml, no_color, verbose,
                 click.echo(click.style(f"Warning: Could not save cache file after determining no tests to run: {e}", fg="yellow"), err=True)
             call_hooks("after_run", [])
             ctx.exit(0) # Exit code 0 as no tests were meant to run.
+
+        if collect_only:
+            click.echo("Collected scenarios:")
+            for s_data in scenarios_to_run:
+                scenario_id_base = s_data['id']
+                param_sets = s_data.get('parameters') or [{'id': 'default', 'vars': {}}]
+                for idx, param in enumerate(param_sets):
+                    param_id = param.get('id', str(idx))
+                    full_id = (
+                        scenario_id_base
+                        if (
+                            s_data.get('parameters') is None
+                            and param_id == 'default'
+                            and len(param_sets) == 1
+                        )
+                        else f"{scenario_id_base}[{param_id}]"
+                    )
+                    click.echo(f"  - {full_id}")
+            ctx.exit(0)
 
         click.echo("\nPreparing to execute Molecule tests for targeted scenarios:")
         try:

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -528,3 +528,24 @@ def test_maxfail_limits_failures(runner, mock_dependencies_three, mock_popen):
     echo_msgs = [c.args[0] for c in mock_dependencies_three.call_args_list]
     assert any('Early termination triggered' in m for m in echo_msgs)
 
+
+def test_collect_only_lists_ids(runner, mock_dependencies_params, mock_popen):
+    """--collect-only should list scenario IDs without executing."""
+    result = runner.invoke(cli, ['run', '--collect-only'])
+    assert result.exit_code == 0
+    assert mock_popen.call_history == []
+    msgs = [c.args[0] for c in mock_dependencies_params['echo'].call_args_list]
+    assert any('role1:alpha[set1]' in m for m in msgs)
+    assert any('role1:alpha[set2]' in m for m in msgs)
+
+
+def test_fixtures_lists_parameter_sets(runner, mock_dependencies_params, mock_popen):
+    """--fixtures should display parameter set names and exit."""
+    result = runner.invoke(cli, ['run', '--fixtures'])
+    assert result.exit_code == 0
+    assert mock_popen.call_history == []
+    msgs = [c.args[0] for c in mock_dependencies_params['echo'].call_args_list]
+    assert any('role1:alpha:' in m for m in msgs)
+    assert any('- set1' in m for m in msgs)
+    assert any('- set2' in m for m in msgs)
+


### PR DESCRIPTION
## Summary
- extend `moltest run` with `--collect-only` and `--fixtures`
- list scenario or fixture info when the flags are used
- document the new options in README
- test that scenario listing happens and Popen is not called

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6845ceb5cec883279b77112d9765f67d