### PR TITLE
fix: restrict setuptools package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,3 +68,6 @@ exclude = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["moltest"]
+
+[tool.setuptools]
+packages = ["moltest"]


### PR DESCRIPTION
## Summary
- fix `setuptools` builds by explicitly listing the package

## Testing
- `pytest -q` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_6845d1b7a8d8832798c6fa3aa70d0fe4