### PR TITLE
feat: stream output with -s

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ moltest run [OPTIONS]
 *   `--md-report [PATH]`, `-m`: Save a Markdown report. Defaults to `moltest_report.md` if no path is provided.
 *   `--junit-xml [PATH]`, `-x`: Save results in JUnit XML format. Defaults to `moltest_report.xml` if no path is provided.
 *   `--roles-path [PATH]`: Directory containing Ansible roles (used for `ANSIBLE_ROLES_PATH`, default: `roles`).
-*   `--capture [MODE]`: Output capture mode (`fd`, `tee`, or `no`). `-s` is shorthand for `--capture no`.
+*   `--capture [MODE]`: Output capture mode (`fd`, `tee`, or `no`). `-s` is shorthand for `--capture no` and streams output in real time.
 *   `--log-level TEXT`: Python logging level (e.g., `INFO`, `DEBUG`).
 *   `--log-file PATH`: Optional file to write logs to.
 *   `--no-color`: Disable colored output in the console. This is automatically enabled in CI environments or when stdout is not a TTY.

--- a/src/moltest/cli.py
+++ b/src/moltest/cli.py
@@ -259,17 +259,18 @@ def _run_scenario(record, verbose, roles_path_resolved, capture, log_level):
             cwd=execution_path,
             env=env,
         ) as proc:
-            if verbose > 0:
+            if capture == 'no':
+                # Always stream output when capture is disabled
                 for line in proc.stdout:
                     formatted = f"      {line.strip()}"
-                    if capture == 'no':
+                    click.echo(formatted)
+                    logger.log(log_level, formatted)
+            elif verbose > 0:
+                for line in proc.stdout:
+                    formatted = f"      {line.strip()}"
+                    if capture == 'tee':
                         click.echo(formatted)
-                        logger.log(log_level, formatted)
-                    elif capture == 'tee':
-                        click.echo(formatted)
-                        output_lines.append(formatted)
-                    else:
-                        output_lines.append(formatted)
+                    output_lines.append(formatted)
             else:
                 proc.wait()
         end_time = time.monotonic()

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -170,6 +170,21 @@ def test_run_streams_output_verbose(runner, mock_dependencies, mock_popen):
     assert mock_popen.wait_called is False
 
 
+def test_run_streams_output_no_verbose(runner, mock_dependencies, mock_popen):
+    """`-s` should stream output even without `-v`."""
+    mock_echo = mock_dependencies
+
+    mock_popen.simulated_stdout_lines = ["Stream line 1\n"]
+    mock_popen.returncode_to_simulate = 0
+
+    result = runner.invoke(cli, ['run', '-s'])
+
+    assert result.exit_code == 0
+
+    assert mock.call("      Stream line 1") in mock_echo.call_args_list
+    assert mock_popen.wait_called is False
+
+
 def test_run_consumes_output_without_verbose(runner, mock_dependencies, mock_popen):
     """Output should not be streamed when no -v flag is provided."""
     mock_echo = mock_dependencies


### PR DESCRIPTION
## Summary
- ensure `-s` streams output without needing `-v`
- document realtime streaming behaviour
- test that `moltest -s` streams output

## Testing
- `pytest -q tests/test_cli_run.py::test_run_streams_output_no_verbose` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_6845e6cc04a48327aa20ca04ae27a948